### PR TITLE
update BaseResourceProfileGraphReader

### DIFF
--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/io/BaseResourceProfileGraphReader.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/io/BaseResourceProfileGraphReader.java
@@ -78,6 +78,10 @@ public class BaseResourceProfileGraphReader {
     }
   }
 
+  public Model getModel() {
+    return this.model;
+  }
+
   protected AbstractResource readResource(Resource node) {
 
     Set<IRI> types = Models.objectIRIs(model.filter(node, RDF.TYPE, null));


### PR DESCRIPTION
added a getter method for the underlying rd4j Model.
- Used by the graphReader implementations to get graph from a given string representation

Useful for testing to see if two representations are the same or not.

- method could be private I think