### PR TITLE
refactor(writer) update signatures

### DIFF
--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractHostable.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractHostable.java
@@ -3,7 +3,6 @@ package ch.unisg.ics.interactions.hmas.core.hostables;
 import ch.unisg.ics.interactions.hmas.core.vocabularies.CORE;
 import ch.unisg.ics.interactions.hmas.core.vocabularies.HMAS;
 import com.google.common.collect.ImmutableSet;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -51,15 +50,6 @@ public abstract class AbstractHostable extends AbstractResource {
     protected AbstractBuilder(HMAS type) {
       super(type);
       this.platforms = new HashSet<>();
-    }
-
-    private static boolean validateIRI(String IRI) {
-      try {
-        SimpleValueFactory.getInstance().createIRI(IRI);
-        return true;
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("The IRI of a Hostable must be valid.");
-      }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractHostable.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractHostable.java
@@ -19,14 +19,9 @@ public abstract class AbstractHostable extends AbstractResource {
    */
   private final transient Set<HypermediaMASPlatform> platforms;
 
-  /**
-   * Construct a hostable resource.
-   *
-   * @param builder the builder of hostables
-   * @return the hostable resource
-   */
   protected AbstractHostable(final HMAS type, final AbstractBuilder builder) {
     super(type, builder);
+    //noinspection unchecked
     this.platforms = ImmutableSet.copyOf(builder.platforms);
   }
 
@@ -52,19 +47,16 @@ public abstract class AbstractHostable extends AbstractResource {
       this.platforms = new HashSet<>();
     }
 
-    @SuppressWarnings("unchecked")
     public S addHMASPlatform(final HypermediaMASPlatform platform) {
       this.platforms.add(platform);
-      return (S) this;
+      return getBuilder();
     }
 
-    @SuppressWarnings("unchecked")
     public S addHMASPlatforms(final Set<HypermediaMASPlatform> platforms) {
       this.platforms.addAll(platforms);
-      return (S) this;
+      return getBuilder();
     }
 
-    @SuppressWarnings("unchecked")
     public abstract T build();
   }
 }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractResource.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractResource.java
@@ -15,6 +15,7 @@ public abstract class AbstractResource implements Resource {
   private final HMAS type;
   private final Set<String> semanticTypes;
 
+  @SuppressWarnings("unchecked")
   protected AbstractResource(final HMAS type, final AbstractBuilder builder) {
 
     this.type = type;
@@ -39,10 +40,7 @@ public abstract class AbstractResource implements Resource {
   }
 
   public Optional<IRI> getIRI() {
-    if (this.IRI.isPresent()) {
-      return Optional.of(SimpleValueFactory.getInstance().createIRI(this.IRI.get()));
-    }
-    return Optional.empty();
+    return this.IRI.map(s -> SimpleValueFactory.getInstance().createIRI(s));
   }
 
   public Optional<String> getIRIAsString() {
@@ -61,6 +59,8 @@ public abstract class AbstractResource implements Resource {
       this.semanticTypes = new HashSet<>();
     }
 
+    abstract protected S getBuilder();
+
     protected static boolean validateIRI(String IRI) {
       try {
         SimpleValueFactory.getInstance().createIRI(IRI);
@@ -70,30 +70,27 @@ public abstract class AbstractResource implements Resource {
       }
     }
 
-    @SuppressWarnings("unchecked")
     public S setIRI(final IRI IRI) {
       this.IRI = Optional.of(IRI.toString());
-      return (S) this;
+      return getBuilder();
     }
 
-    @SuppressWarnings("unchecked")
     public S setIRIAsString(final String IRI) {
       validateIRI(IRI);
       this.IRI = Optional.of(IRI);
-      return (S) this;
+      return getBuilder();
     }
 
     public S addSemanticType(final String type) {
       this.semanticTypes.add(type);
-      return (S) this;
+      return getBuilder();
     }
 
     public S addSemanticTypes(final Set<String> types) {
       this.semanticTypes.addAll(types);
-      return (S) this;
+      return getBuilder();
     }
 
-    @SuppressWarnings("unchecked")
     public abstract T build();
   }
 }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractResource.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/AbstractResource.java
@@ -61,7 +61,7 @@ public abstract class AbstractResource implements Resource {
       this.semanticTypes = new HashSet<>();
     }
 
-    private static boolean validateIRI(String IRI) {
+    protected static boolean validateIRI(String IRI) {
       try {
         SimpleValueFactory.getInstance().createIRI(IRI);
         return true;

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/Agent.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/Agent.java
@@ -12,6 +12,11 @@ public class Agent extends AbstractHostable implements ProfiledResource {
   public static class Builder extends AbstractBuilder<Builder, Agent> {
     public static final HMAS TYPE = CORE.TERM.AGENT;
 
+    @Override
+    protected Builder getBuilder() {
+      return this;
+    }
+
     public Agent build() {
       return new Agent(this);
     }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/Artifact.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/Artifact.java
@@ -16,6 +16,11 @@ public class Artifact extends AbstractHostable implements ProfiledResource {
   public static class Builder extends AbstractBuilder<Builder, Artifact> {
     public static final HMAS TYPE = CORE.TERM.ARTIFACT;
 
+    @Override
+    protected Builder getBuilder() {
+      return this;
+    }
+
     public Artifact build() {
       return new Artifact(this);
     }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/BaseResourceProfile.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/BaseResourceProfile.java
@@ -20,6 +20,11 @@ public class BaseResourceProfile extends AbstractHostable {
       super(resource);
     }
 
+    @Override
+    protected Builder getBuilder() {
+      return this;
+    }
+
     public BaseResourceProfile build() {
       return new BaseResourceProfile(this);
     }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/BaseSignifier.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/BaseSignifier.java
@@ -12,6 +12,11 @@ public class BaseSignifier extends AbstractHostable {
   public static class Builder extends AbstractBuilder<Builder, BaseSignifier> {
     public static final HMAS TYPE = CORE.TERM.SIGNIFIER;
 
+    @Override
+    protected Builder getBuilder() {
+      return this;
+    }
+
     public BaseSignifier build() {
       return new BaseSignifier(this);
     }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/HypermediaMASPlatform.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/HypermediaMASPlatform.java
@@ -16,6 +16,7 @@ public class HypermediaMASPlatform extends AbstractResource implements ProfiledR
     this(CORE.TERM.HMAS_PLATFORM, builder);
   }
 
+  @SuppressWarnings("unchecked")
   protected HypermediaMASPlatform(HMAS type, AbstractBuilder builder) {
     super(type, builder);
     this.hostedResources = ImmutableSet.copyOf(builder.hostedResources);
@@ -26,6 +27,11 @@ public class HypermediaMASPlatform extends AbstractResource implements ProfiledR
   }
 
   public static class Builder extends AbstractBuilder<Builder, HypermediaMASPlatform> {
+
+    @Override
+    protected Builder getBuilder() {
+      return this;
+    }
 
     public HypermediaMASPlatform build() {
       return new HypermediaMASPlatform(this);
@@ -48,12 +54,12 @@ public class HypermediaMASPlatform extends AbstractResource implements ProfiledR
 
     public S addHostedResource(final AbstractHostable hostable) {
       this.hostedResources.add(hostable);
-      return (S) this;
+      return getBuilder();
     }
 
     public S addHostedResources(final Set<AbstractHostable> hostables) {
       this.hostedResources.addAll(hostables);
-      return (S) this;
+      return getBuilder();
     }
 
     public abstract T build();

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/Workspace.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/hostables/Workspace.java
@@ -21,6 +21,11 @@ public class Workspace extends Artifact {
 
   public static class Builder extends AbstractBuilder<Builder, Workspace> {
 
+    @Override
+    protected Builder getBuilder() {
+      return this;
+    }
+
     public Workspace build() {
       return new Workspace(this);
     }
@@ -37,12 +42,12 @@ public class Workspace extends Artifact {
 
     public S addContainedResource(AbstractHostable hostable) {
       this.containedResources.add(hostable);
-      return (S) this;
+      return getBuilder();
     }
 
     public S addContainedResources(Set<AbstractHostable> hostables) {
       this.containedResources.addAll(hostables);
-      return (S) this;
+      return getBuilder();
     }
 
     public abstract T build();

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/io/BaseResourceProfileGraphReader.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/io/BaseResourceProfileGraphReader.java
@@ -58,9 +58,7 @@ public class BaseResourceProfileGraphReader {
                     .addSemanticTypes(reader.readSemanticTypes());
 
     Optional<IRI> profileIRI = reader.readProfileIRI();
-    if (profileIRI.isPresent()) {
-      profileBuilder.setIRI(profileIRI.get());
-    }
+    profileIRI.ifPresent(profileBuilder::setIRI);
 
     return profileBuilder.build();
   }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/io/BaseResourceProfileGraphWriter.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/io/BaseResourceProfileGraphWriter.java
@@ -67,8 +67,8 @@ public class BaseResourceProfileGraphWriter<T extends BaseResourceProfile> imple
   }
 
   private BaseResourceProfileGraphWriter addOwnerResource() {
-    ProfiledResource resource = profile.getResource();
-    Resource node = resolveHostableLocation((AbstractResource) resource);
+    AbstractResource resource = (AbstractResource) profile.getResource();
+    Resource node = resolveHostableLocation(resource);
     this.graphBuilder.add(profileIRI, IS_PROFILE_OF, node);
     writeResource(resource, node);
     return this;
@@ -84,7 +84,7 @@ public class BaseResourceProfileGraphWriter<T extends BaseResourceProfile> imple
     return this;
   }
 
-  private BaseResourceProfileGraphWriter writeResource(ProfiledResource resource, Resource node) {
+  private BaseResourceProfileGraphWriter writeResource(AbstractResource resource, Resource node) {
 
     if (AGENT.equals(resource.getTypeAsIRI())) {
       addAgent((Agent) resource, node);
@@ -115,7 +115,7 @@ public class BaseResourceProfileGraphWriter<T extends BaseResourceProfile> imple
     for (AbstractHostable containedResource : contained) {
       Resource containedNode = resolveHostableLocation(containedResource);
       graphBuilder.add(node, CONTAINS, containedNode);
-      writeResource((ProfiledResource) containedResource, containedNode);
+      writeResource(containedResource, containedNode);
     }
     addHostable(workspace, node);
     return this;
@@ -126,7 +126,7 @@ public class BaseResourceProfileGraphWriter<T extends BaseResourceProfile> imple
     for (AbstractHostable hostedResource : hosted) {
       Resource hostedNode = resolveHostableLocation(hostedResource);
       graphBuilder.add(node, HOSTS, hostedNode);
-      writeResource((ProfiledResource) hostedResource, hostedNode);
+      writeResource(hostedResource, hostedNode);
     }
     addResource(platform, node);
     return this;
@@ -147,11 +147,11 @@ public class BaseResourceProfileGraphWriter<T extends BaseResourceProfile> imple
       graphBuilder.add(node, RDF.TYPE, rdf.createIRI(type));
     }
 
-    addResource((ProfiledResource) resource, node);
+    addResource(resource, node);
     return this;
   }
 
-  protected BaseResourceProfileGraphWriter addResource(ProfiledResource resource, Resource node) {
+  protected BaseResourceProfileGraphWriter addResource(AbstractResource resource, Resource node) {
     graphBuilder.add(node, RDF.TYPE, resource.getTypeAsIRI());
 
     Set<String> semanticTypes = resource.getSemanticTypes();

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/io/InvalidResourceProfileException.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/io/InvalidResourceProfileException.java
@@ -2,8 +2,6 @@ package ch.unisg.ics.interactions.hmas.core.io;
 
 public class InvalidResourceProfileException extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
-
   public InvalidResourceProfileException(String errorMessage) {
     super(errorMessage);
   }

--- a/src/main/java/ch/unisg/ics/interactions/hmas/core/vocabularies/CORE.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/core/vocabularies/CORE.java
@@ -38,6 +38,8 @@ public class CORE {
 
   public static final IRI EXPOSES_SIGNIFIER;
 
+  public static final IRI HAS_PROFILE;
+
   public static final IRI IS_PROFILE_OF;
 
   public static final IRI TRANSITIVELY_CONTAINS;
@@ -60,6 +62,7 @@ public class CORE {
     HOSTS = rdf.createIRI(NAMESPACE + "hosts");
     IS_HOSTED_ON = rdf.createIRI(NAMESPACE + "isHostedOn");
     EXPOSES_SIGNIFIER = rdf.createIRI(NAMESPACE + "exposesSignifier");
+    HAS_PROFILE = rdf.createIRI(NAMESPACE + "hasProfile");
     IS_PROFILE_OF = rdf.createIRI(NAMESPACE + "isProfileOf");
     TRANSITIVELY_CONTAINS = rdf.createIRI(NAMESPACE + "transitivelyContains");
     IS_TRANSITIVELY_CONTAINED_IN = rdf.createIRI(NAMESPACE + "isTransitivelyContainedIn");
@@ -85,6 +88,7 @@ public class CORE {
     HOSTS(CORE.HOSTS),
     IS_HOSTED_ON(CORE.IS_HOSTED_ON),
     EXPOSES_SIGNIFIER(CORE.EXPOSES_SIGNIFIER),
+    HAS_PROFILE(CORE.HAS_PROFILE),
     IS_PROFILE_OF(CORE.IS_PROFILE_OF),
     TRANSITIVELY_CONTAINS(CORE.TRANSITIVELY_CONTAINS),
     IS_TRANSITIVELY_CONTAINED_IN(CORE.IS_TRANSITIVELY_CONTAINED_IN);


### PR DESCRIPTION
Updates in writer: `AbstractResource` -> `ProfiledResource` in methods that do not refer necessarily to the owner resource.